### PR TITLE
Refactored community join method

### DIFF
--- a/src/bami/backbone/block_sync.py
+++ b/src/bami/backbone/block_sync.py
@@ -96,6 +96,17 @@ class BlockSyncMixin(MessageStateMachine, CommunityRoutines, metaclass=ABCMeta):
         """
         pass
 
+    @abstractmethod
+    def received_block_in_order(self, block: BamiBlock) -> None:
+        """
+        Process a block that we have received.
+
+        Args:
+            block: The received block.
+
+        """
+        pass
+
     def validate_persist_block(self, block: BamiBlock, peer: Peer = None) -> bool:
         """
         Validate a block and if it's valid, persist it.

--- a/src/bami/backbone/community.py
+++ b/src/bami/backbone/community.py
@@ -211,6 +211,22 @@ class BamiCommunity(
         """
         return IPv8SubCommunity(*args, **kwargs)
 
+    def on_join_subcommunity(self, sub_com_id: bytes) -> None:
+        """
+        This method is called when BAMI joins a new sub-community.
+        We enable some functionality by default, but custom behaviour can be added by overriding this method.
+
+        Args:
+            sub_com_id: The ID of the sub-community we just joined.
+
+        """
+        if self.settings.frontier_gossip_enabled:
+            # Start exchanging frontiers
+            self.start_frontier_gossip_sync(sub_com_id)
+
+        # By default, add a handler that is called with subsequent blocks
+        self.subscribe_in_order_block(sub_com_id, self.received_block_in_order)
+
     # ----- Discovery start -----
     def start_discovery(
         self,

--- a/src/bami/backbone/settings.py
+++ b/src/bami/backbone/settings.py
@@ -40,6 +40,8 @@ class BamiSettings(object):
         # Track chains of every overlay neighbour
         self.track_neighbours_chains = False
 
+        # Whether frontier gossip is enabled
+        self.frontier_gossip_enabled = True
         # Maximum delay before starting the frontier sync in the community
         self.frontier_gossip_sync_max_delay = 0.1
         # The interval at which we gossip the latest frontier in each community

--- a/src/bami/backbone/sub_community.py
+++ b/src/bami/backbone/sub_community.py
@@ -149,7 +149,7 @@ class SubCommunityRoutines(ABC):
         pass
 
     @abstractmethod
-    def join_subcommunity_gossip(self, sub_com_id: bytes) -> None:
+    def on_join_subcommunity(self, sub_com_id: bytes) -> None:
         """
         Join to the gossip process for the sub-community
         Args:
@@ -199,7 +199,7 @@ class SubCommunityMixin(SubCommunityRoutines, CommunityRoutines, metaclass=ABCMe
             if c_id not in self.my_subcoms:
                 self.join_subcom(c_id, discovery_params)
                 # Join the sub-community
-                self.join_subcommunity_gossip(c_id)
+                self.on_join_subcommunity(c_id)
                 updated = True
         if updated:
             self.notify_peers_on_new_subcoms()
@@ -219,7 +219,7 @@ class SubCommunityMixin(SubCommunityRoutines, CommunityRoutines, metaclass=ABCMe
             self.join_subcom(subcom_id, discovery_params)
 
             # Join the protocol audits/ updates
-            self.join_subcommunity_gossip(subcom_id)
+            self.on_join_subcommunity(subcom_id)
 
             # Notify other peers that you are part of the new community
             self.notify_peers_on_new_subcoms()

--- a/src/bami/payment/community.py
+++ b/src/bami/payment/community.py
@@ -80,17 +80,13 @@ class PaymentCommunity(BamiCommunity, metaclass=ABCMeta):
     def settings(self) -> PaymentSettings:
         return super().settings
 
-    def join_subcommunity_gossip(self, sub_com_id: bytes) -> None:
-        # 0. Add master peer to the known minter group
+    def on_join_subcommunity(self, sub_com_id: bytes) -> None:
+        super(PaymentCommunity, self).on_join_subcommunity(sub_com_id)
+
+        # Add master peer to the known minter group
         self.state_db.add_known_minters(sub_com_id, {sub_com_id})
 
-        # 1. Main payment chain: spends and their confirmations
-        # - Start gossip sync task periodically on the chain updates
-        self.start_frontier_gossip_sync(sub_com_id)
-        # - Process incoming blocks on the chain in order for payments
-        self.subscribe_in_order_block(sub_com_id, self.received_block_in_order)
-
-        # 2. Witness chain:
+        # Witness chain:
         # - Gossip witness updates on the sub-chain
         self.start_frontier_gossip_sync(sub_com_id, prefix=b"w")
         # - Process witness block out of order

--- a/tests/backbone/test_block_sync.py
+++ b/tests/backbone/test_block_sync.py
@@ -25,6 +25,9 @@ class BlockSyncCommunity(MockedCommunity, BlockSyncMixin):
     def process_block_unordered(self, blk: BamiBlock, peer: Peer) -> None:
         pass
 
+    def received_block_in_order(self, block: BamiBlock) -> None:
+        pass
+
 
 NUM_NODES = 2
 

--- a/tests/integration/test_backbone.py
+++ b/tests/integration/test_backbone.py
@@ -34,10 +34,10 @@ class SimpleCommunity(BamiCommunity):
     def create_subcom(self, *args, **kwargs) -> BaseSubCommunity:
         return LightSubCommunity(*args, **kwargs)
 
-    def join_subcommunity_gossip(self, sub_com_id: bytes) -> None:
+    def witness_tx_well_formatted(self, witness_tx: Any) -> bool:
         pass
 
-    def witness_tx_well_formatted(self, witness_tx: Any) -> bool:
+    def received_block_in_order(self, block: BamiBlock) -> None:
         pass
 
 
@@ -69,9 +69,6 @@ async def test_simple_frontier_reconciliation_after_partition(set_vals):
     """
     Test whether missing blocks are synchronized after a network partition.
     """
-    set_vals.nodes[0].overlay.start_frontier_gossip_sync(set_vals.community_id)
-    set_vals.nodes[1].overlay.start_frontier_gossip_sync(set_vals.community_id)
-
     for _ in range(3):
         # Note that we do not broadcast the block to the other node
         set_vals.nodes[0].overlay.create_signed_block(com_id=set_vals.community_id)

--- a/tests/mocking/community.py
+++ b/tests/mocking/community.py
@@ -106,7 +106,7 @@ class MockSubCommunityRoutines(SubCommunityRoutines):
     def notify_peers_on_new_subcoms(self) -> None:
         pass
 
-    def join_subcommunity_gossip(self, sub_com_id: bytes) -> None:
+    def on_join_subcommunity(self, sub_com_id: bytes) -> None:
         pass
 
     @property
@@ -189,7 +189,7 @@ class FakeBackCommunity(BamiCommunity):
     def process_block_unordered(self, blk: BamiBlock, peer: Peer) -> None:
         pass
 
-    def join_subcommunity_gossip(self, sub_com_id: bytes) -> None:
+    def received_block_in_order(self, block: BamiBlock) -> None:
         pass
 
 


### PR DESCRIPTION
By default, we now start to exchange frontiers when joining a new community (if this is enabled in the settings). We also subscribe to in-order blocks. Custom logic can be added by overriding the on_join_subcommunity method, for example, as done by the PaymentCommunity.

Fixes #12