### PR TITLE
Unite set_vals implementations

### DIFF
--- a/tests/backbone/test_block_sync.py
+++ b/tests/backbone/test_block_sync.py
@@ -6,17 +6,11 @@ from bami.backbone.payload import (
     BlockBroadcastPayload,
     RawBlockBroadcastPayload,
 )
-from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.peer import Peer
 import pytest
 
 from tests.conftest import FakeBlock
-from tests.mocking.base import (
-    create_and_connect_nodes,
-    deliver_messages,
-    SetupValues,
-    unload_nodes,
-)
+from tests.mocking.base import deliver_messages
 from tests.mocking.community import MockedCommunity
 from tests.mocking.mock_db import MockDBManager
 
@@ -29,39 +23,32 @@ class BlockSyncCommunity(MockedCommunity, BlockSyncMixin):
         pass
 
 
-NUM_NODES = 2
-
-
 @pytest.fixture()
 def overlay_class():
     return BlockSyncCommunity
 
 
 @pytest.fixture()
-async def set_vals(tmpdir_factory, overlay_class):
-    dirs = [
-        tmpdir_factory.mktemp(str(overlay_class.__name__), numbered=True)
-        for _ in range(NUM_NODES)
-    ]
-    nodes = create_and_connect_nodes(NUM_NODES, work_dirs=dirs, ov_class=overlay_class)
-    # Make sure every node has a community to listen to
-    community_key = default_eccrypto.generate_key(u"curve25519").pub()
-    community_id = community_key.key_to_bin()
-    yield SetupValues(nodes=nodes, community_id=community_id)
-    await unload_nodes(nodes)
-    for k in dirs:
-        k.remove(ignore_errors=True)
+def init_nodes():
+    return False
 
 
-def test_init_setup(set_vals):
-    assert set_vals.nodes[0].overlay.decode_map[RawBlockBroadcastPayload.msg_id]
-    assert set_vals.nodes[0].overlay.decode_map[BlockBroadcastPayload.msg_id]
+@pytest.fixture()
+def num_nodes():
+    return 2
+
+
+def test_init_setup(set_vals_by_key):
+    assert set_vals_by_key.nodes[0].overlay.decode_map[RawBlockBroadcastPayload.msg_id]
+    assert set_vals_by_key.nodes[0].overlay.decode_map[BlockBroadcastPayload.msg_id]
 
 
 @pytest.mark.asyncio
-async def test_send_receive_block(monkeypatch, mocker, set_vals):
+async def test_send_receive_block(monkeypatch, mocker, set_vals_by_key):
     blk = FakeBlock(transaction=b"test")
-    set_vals.nodes[0].overlay.send_block(blk, [set_vals.nodes[1].overlay.my_peer])
+    set_vals_by_key.nodes[0].overlay.send_block(
+        blk, [set_vals_by_key.nodes[1].overlay.my_peer]
+    )
     monkeypatch.setattr(MockDBManager, "add_block", lambda _, __, ___, prefix: None)
     monkeypatch.setattr(MockDBManager, "has_block", lambda _, __: False)
 
@@ -72,10 +59,10 @@ async def test_send_receive_block(monkeypatch, mocker, set_vals):
 
 
 @pytest.mark.asyncio
-async def test_send_receive_raw_block(monkeypatch, mocker, set_vals):
+async def test_send_receive_raw_block(monkeypatch, mocker, set_vals_by_key):
     blk = FakeBlock(transaction=b"test")
-    set_vals.nodes[0].overlay.send_block(
-        blk.pack(), [set_vals.nodes[1].overlay.my_peer]
+    set_vals_by_key.nodes[0].overlay.send_block(
+        blk.pack(), [set_vals_by_key.nodes[1].overlay.my_peer]
     )
     monkeypatch.setattr(MockDBManager, "add_block", lambda _, __, ___, prefix: None)
     monkeypatch.setattr(MockDBManager, "has_block", lambda _, __: False)
@@ -84,19 +71,19 @@ async def test_send_receive_raw_block(monkeypatch, mocker, set_vals):
     spy.assert_called_with(ANY, blk.hash)
 
 
-def test_create_block(monkeypatch, mocker, set_vals):
+def test_create_block(monkeypatch, mocker, set_vals_by_key):
     monkeypatch.setattr(MockDBManager, "add_block", lambda _, __, ___: None)
     monkeypatch.setattr(MockDBManager, "has_block", lambda _, __: False)
     spy = mocker.spy(MockDBManager, "has_block")
-    blk = set_vals.nodes[0].overlay.create_signed_block()
+    blk = set_vals_by_key.nodes[0].overlay.create_signed_block()
     spy.assert_called_with(ANY, blk.hash)
 
 
 @pytest.mark.asyncio
-async def test_send_incorrect_block(monkeypatch, mocker, set_vals):
+async def test_send_incorrect_block(monkeypatch, mocker, set_vals_by_key):
     blk = FakeBlock(transaction=b"test")
-    set_vals.nodes[0].overlay.send_block(
-        blk.pack(signature=False), [set_vals.nodes[1].overlay.my_peer]
+    set_vals_by_key.nodes[0].overlay.send_block(
+        blk.pack(signature=False), [set_vals_by_key.nodes[1].overlay.my_peer]
     )
     spy = mocker.spy(BamiBlock, "unpack")
     spy2 = mocker.spy(BamiBlock, "block_invariants_valid")

--- a/tests/backbone/test_community.py
+++ b/tests/backbone/test_community.py
@@ -4,16 +4,12 @@ from bami.backbone.payload import (
     BlockBroadcastPayload,
     RawBlockBroadcastPayload,
 )
-from ipv8.keyvault.crypto import default_eccrypto
 import pytest
 
 from tests.conftest import FakeBlock
 from tests.mocking.base import (
-    create_and_connect_nodes,
     deliver_messages,
     introduce_nodes,
-    SetupValues,
-    unload_nodes,
 )
 from tests.mocking.community import (
     FakeIPv8BackCommunity,
@@ -28,73 +24,70 @@ def overlay_class(request):
     return request.param
 
 
-@pytest.fixture()
-async def set_vals(tmpdir_factory, overlay_class):
-    dirs = [
-        tmpdir_factory.mktemp(str(overlay_class.__name__), numbered=True)
-        for _ in range(NUM_NODES)
-    ]
-    nodes = create_and_connect_nodes(NUM_NODES, work_dirs=dirs, ov_class=overlay_class)
-    # Make sure every node has a community to listen to
-    community_key = default_eccrypto.generate_key(u"curve25519").pub()
-    community_id = community_key.key_to_bin()
-    for node in nodes:
-        node.overlay.subscribe_to_subcom(community_id)
-    yield SetupValues(nodes=nodes, community_id=community_id)
-    await unload_nodes(nodes)
-    for k in dirs:
-        k.remove(ignore_errors=True)
+@pytest.fixture
+def init_nodes():
+    return True
+
+
+@pytest.fixture
+def num_nodes():
+    return NUM_NODES
 
 
 @pytest.mark.asyncio
-async def test_share_in_community(mocker, set_vals):
-    blk = FakeBlock(com_id=set_vals.community_id)
-    set_vals.nodes[0].overlay.share_in_community(blk, set_vals.community_id)
-    spy = mocker.spy(set_vals.nodes[1].overlay, "validate_persist_block")
+async def test_share_in_community(mocker, set_vals_by_key):
+    blk = FakeBlock(com_id=set_vals_by_key.community_id)
+    set_vals_by_key.nodes[0].overlay.share_in_community(
+        blk, set_vals_by_key.community_id
+    )
+    spy = mocker.spy(set_vals_by_key.nodes[1].overlay, "validate_persist_block")
     await deliver_messages()
-    spy.assert_called_once_with(blk, set_vals.nodes[0].overlay.my_peer)
+    spy.assert_called_once_with(blk, set_vals_by_key.nodes[0].overlay.my_peer)
 
 
 @pytest.mark.asyncio
-async def test_confirm_block(mocker, set_vals):
-    blk = FakeBlock(com_id=set_vals.community_id)
-    set_vals.nodes[0].overlay.confirm(blk)
-    spy = mocker.spy(set_vals.nodes[1].overlay, "validate_persist_block")
+async def test_confirm_block(mocker, set_vals_by_key):
+    blk = FakeBlock(com_id=set_vals_by_key.community_id)
+    set_vals_by_key.nodes[0].overlay.confirm(blk)
+    spy = mocker.spy(set_vals_by_key.nodes[1].overlay, "validate_persist_block")
     await deliver_messages()
-    spy.assert_called_with(ANY, set_vals.nodes[0].overlay.my_peer)
+    spy.assert_called_with(ANY, set_vals_by_key.nodes[0].overlay.my_peer)
 
 
 @pytest.mark.asyncio
-async def test_reject_block(mocker, set_vals):
-    blk = FakeBlock(com_id=set_vals.community_id)
-    set_vals.nodes[0].overlay.reject(blk)
-    spy = mocker.spy(set_vals.nodes[1].overlay, "validate_persist_block")
+async def test_reject_block(mocker, set_vals_by_key):
+    blk = FakeBlock(com_id=set_vals_by_key.community_id)
+    set_vals_by_key.nodes[0].overlay.reject(blk)
+    spy = mocker.spy(set_vals_by_key.nodes[1].overlay, "validate_persist_block")
     await deliver_messages()
-    spy.assert_called_with(ANY, set_vals.nodes[0].overlay.my_peer)
+    spy.assert_called_with(ANY, set_vals_by_key.nodes[0].overlay.my_peer)
 
 
-def test_init_setup(set_vals):
-    assert set_vals.nodes[0].overlay.decode_map[RawBlockBroadcastPayload.msg_id]
-    assert set_vals.nodes[0].overlay.decode_map[BlockBroadcastPayload.msg_id]
+def test_init_setup(set_vals_by_key):
+    assert set_vals_by_key.nodes[0].overlay.decode_map[RawBlockBroadcastPayload.msg_id]
+    assert set_vals_by_key.nodes[0].overlay.decode_map[BlockBroadcastPayload.msg_id]
 
 
-def test_subscribe(set_vals):
-    assert set_vals.nodes[0].overlay.is_subscribed(set_vals.community_id)
-    assert set_vals.nodes[1].overlay.is_subscribed(set_vals.community_id)
+def test_subscribe(set_vals_by_key):
+    assert set_vals_by_key.nodes[0].overlay.is_subscribed(set_vals_by_key.community_id)
+    assert set_vals_by_key.nodes[1].overlay.is_subscribed(set_vals_by_key.community_id)
 
 
 @pytest.mark.asyncio
-async def test_peers_introduction(mocker, set_vals):
-    spy = mocker.spy(set_vals.nodes[1].overlay, "process_peer_subscriptions")
-    await introduce_nodes(set_vals.nodes)
+async def test_peers_introduction(mocker, set_vals_by_key):
+    spy = mocker.spy(set_vals_by_key.nodes[1].overlay, "process_peer_subscriptions")
+    await introduce_nodes(set_vals_by_key.nodes)
     spy.assert_called()
     for i in range(NUM_NODES):
-        assert len(set_vals.nodes[i].overlay.my_subcoms) == 1
-        assert set_vals.nodes[i].overlay.get_subcom(set_vals.community_id) is not None
+        assert len(set_vals_by_key.nodes[i].overlay.my_subcoms) == 1
+        assert (
+            set_vals_by_key.nodes[i].overlay.get_subcom(set_vals_by_key.community_id)
+            is not None
+        )
         assert (
             len(
-                set_vals.nodes[i]
-                .overlay.get_subcom(set_vals.community_id)
+                set_vals_by_key.nodes[i]
+                .overlay.get_subcom(set_vals_by_key.community_id)
                 .get_known_peers()
             )
             > 0

--- a/tests/backbone/test_utils.py
+++ b/tests/backbone/test_utils.py
@@ -1,6 +1,6 @@
-from unittest.mock import Mock
-
 import pytest
+
+from unittest.mock import Mock
 from bami.backbone.utils import (
     decode_links,
     decode_raw,

--- a/tests/integration/test_backbone.py
+++ b/tests/integration/test_backbone.py
@@ -8,12 +8,7 @@ from bami.backbone.community import BamiCommunity
 from bami.backbone.sub_community import BaseSubCommunity, LightSubCommunity
 from bami.backbone.utils import decode_raw, encode_raw
 from ipv8.keyvault.crypto import default_eccrypto
-from tests.mocking.base import (
-    SetupValues,
-    unload_nodes,
-    create_and_connect_nodes,
-    deliver_messages,
-)
+from tests.mocking.base import deliver_messages
 
 
 class SimpleCommunity(BamiCommunity):
@@ -56,45 +51,42 @@ class BlockResponseCommunity(BlockResponseMixin, SimpleCommunity):
 
 
 @pytest.fixture
-async def set_vals(tmpdir_factory, community_cls, num_nodes):
-    dirs = [
-        tmpdir_factory.mktemp(str(SimpleCommunity.__name__), numbered=True)
-        for _ in range(num_nodes)
-    ]
-    nodes = create_and_connect_nodes(num_nodes, work_dirs=dirs, ov_class=community_cls)
-    # Make sure every node has a community to listen to
-    community_key = default_eccrypto.generate_key("curve25519").pub()
-    community_id = community_key.key_to_bin()
-    for node in nodes:
-        node.overlay.subscribe_to_subcom(community_id)
-    yield SetupValues(nodes=nodes, community_id=community_id)
-    await unload_nodes(nodes)
-    for k in dirs:
-        k.remove(ignore_errors=True)
+def init_nodes():
+    return True
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("community_cls", [SimpleCommunity])
+@pytest.mark.parametrize("overlay_class", [SimpleCommunity])
 @pytest.mark.parametrize("num_nodes", [2])
-async def test_simple_frontier_reconciliation_after_partition(set_vals):
+async def test_simple_frontier_reconciliation_after_partition(set_vals_by_key):
     """
     Test whether missing blocks are synchronized after a network partition.
     """
     for _ in range(3):
         # Note that we do not broadcast the block to the other node
-        set_vals.nodes[0].overlay.create_signed_block(com_id=set_vals.community_id)
+        set_vals_by_key.nodes[0].overlay.create_signed_block(
+            com_id=set_vals_by_key.community_id
+        )
 
     # Force frontier exchange
-    set_vals.nodes[0].overlay.frontier_gossip_sync_task(set_vals.community_id)
-    set_vals.nodes[1].overlay.frontier_gossip_sync_task(set_vals.community_id)
+    set_vals_by_key.nodes[0].overlay.frontier_gossip_sync_task(
+        set_vals_by_key.community_id
+    )
+    set_vals_by_key.nodes[1].overlay.frontier_gossip_sync_task(
+        set_vals_by_key.community_id
+    )
 
     await deliver_messages()
 
     frontier1 = (
-        set_vals.nodes[0].overlay.persistence.get_chain(set_vals.community_id).frontier
+        set_vals_by_key.nodes[0]
+        .overlay.persistence.get_chain(set_vals_by_key.community_id)
+        .frontier
     )
     frontier2 = (
-        set_vals.nodes[1].overlay.persistence.get_chain(set_vals.community_id).frontier
+        set_vals_by_key.nodes[1]
+        .overlay.persistence.get_chain(set_vals_by_key.community_id)
+        .frontier
     )
     assert len(frontier2.terminal) == 1
     assert frontier2.terminal[0][0] == 3
@@ -102,16 +94,18 @@ async def test_simple_frontier_reconciliation_after_partition(set_vals):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("community_cls", [BlockResponseCommunity])
+@pytest.mark.parametrize("overlay_class", [BlockResponseCommunity])
 @pytest.mark.parametrize("num_nodes", [2])
-async def test_block_confirm(set_vals):
+async def test_block_confirm(set_vals_by_key):
     """
     Test whether blocks are confirmed correctly.
     """
-    block = set_vals.nodes[0].overlay.create_signed_block(
-        com_id=set_vals.community_id,
+    block = set_vals_by_key.nodes[0].overlay.create_signed_block(
+        com_id=set_vals_by_key.community_id,
         transaction=encode_raw({b"to_peer": 3}),
         block_type=b"good",
     )
-    set_vals.nodes[0].overlay.share_in_community(block, set_vals.community_id)
+    set_vals_by_key.nodes[0].overlay.share_in_community(
+        block, set_vals_by_key.community_id
+    )
     await deliver_messages()


### PR DESCRIPTION
A clean history version of #53 

United the set_vals implementations into two functions. This is to avoid
code reduplication. Currently pytest does not allow class-based
fixtures, so the functions could not be united under a single class.

Add param to function signature

Added a parameter to the functions' signature. This allowes greater
flexibility in their usage.

Modify tests to work with new set_vals functions

Modified tests to work with new `set_vals` functions. Those are now
defined in one file instead of being implemented a number of times over
different files.

Minor reordering of imports in one file.

Fixes #45 .