### PR TITLE
Flake8 + black improvements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,9 @@
 # .flake8
 [flake8]
 select = ANN,B,B9,BLK,C,DAR,E,F,W,I,S
-ignore = E203,W503,E501
+ignore = E203,W503,E501,ANN101,ANN102
 max-line-length = 88
-application-import-names = python_project,tests
-import-order-style = google
+application-import-names = python_project,tests,bami
+import-order-style = cryptography
 per-file-ignores = tests/*:S101,ANN
                    noxfile.py:ANN

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,4 +16,5 @@ jobs:
         architecture: x64
     - run: pip install nox==2021.6.6
     - run: pip install poetry==1.1.6
-    - run: nox
+    - run: nox -s black_check
+    - run: nox -s tests

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ nox.options.sessions = (
     "black",
     "tests",
 )
-# Additional options "safety", "lint", "lint", "mypy", "pytype"
+# Additional options "safety", "lint", "mypy", "pytype"
 package = "bami"
 
 
@@ -39,7 +39,6 @@ def lint(session: Session) -> None:
         session,
         "flake8",
         "flake8-black",
-        "flake8-bandit",
         "flake8-bandit",
         "flake8-import-order",
         "flake8-annotations",

--- a/noxfile.py
+++ b/noxfile.py
@@ -82,6 +82,14 @@ def black(session: Session) -> None:
 
 
 @nox.session(python="3.9")
+def black_check(session: Session) -> None:
+    """Run black code formatter checker."""
+    args = session.posargs or ["--check", *locations]
+    install_with_constraints(session, "black")
+    session.run("black", *args)
+
+
+@nox.session(python="3.9")
 def mypy(session: Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or locations


### PR DESCRIPTION
Fixes #30

I'm setting the cryptography standard as default since that is also the one we use for other software in our lab (Tribler/IPv8 etc). I'm also ignoring a few flake8 warnings as suggested by [Hypermodern Python Cookiecutter](https://github.com/cjolowicz/cookiecutter-hypermodern-python).